### PR TITLE
CPU meter like tmux-mem-cpu-load

### DIFF
--- a/scripts/basic-cpu-and-memory.tmux
+++ b/scripts/basic-cpu-and-memory.tmux
@@ -4,27 +4,33 @@
 Basic CPU & Memory Usage for Tmux
 
 Author: Zaiste! <oh@zaiste.net>
+
+Dash-meter inspired by tmux-mem-cpu
+and code from psutil top.py.
 """
 
 import os
+import sys
 if os.name != 'posix':
         sys.exit('platform not supported')
 import psutil
 
+
+def get_dashes(perc):
+    dashes = "|" * int((float(perc) / 10))
+    empty_dashes = " " * (10 - len(dashes))
+    return dashes, empty_dashes
+
+
 def info():
     phymem = psutil.phymem_usage()
-    used = phymem.total - phymem.free
 
-    vmem = psutil.virtmem_usage()
-
-
-    line = "%s | %s %4s%% | %s %4s%%" % (
+    cpu_dashes, cpu_empty_dashes = get_dashes(psutil.cpu_percent(interval=0.1))
+    line = "%s/%sMB [%s%s] %s%%" % (
+        str(int(phymem.used / 1024 / 1024)),
+        str(int(phymem.total / 1024 / 1024)),
+        cpu_dashes, cpu_empty_dashes,
         psutil.cpu_percent(interval=0.1),
-        str(int(used / 1024 / 1024)) + "M",
-        phymem.percent,
-        str(int(vmem.used / 1024 / 1024)) + "M",
-        vmem.percent,
-
     )
 
     return line


### PR DESCRIPTION
Hi.

![screenie](http://i.imgur.com/q72Uk.png)

Here is the `status-right` I use for the time.

`set -g status-right '#[fg=green] #(basic-cpu-and-memory.tmux) #[fg=red,dim]#(uptime | cut -f 4-5 -d " " | cut -f 1 -d ",") #[fg=white]%a%l:%M:%S %p#[default] #[fg=blue]%Y-%m-%d'`

Care to give it a test?
