### PR TITLE
Improve memory readings

### DIFF
--- a/scripts/basic-cpu-and-memory.tmux
+++ b/scripts/basic-cpu-and-memory.tmux
@@ -23,12 +23,13 @@ def get_dashes(perc):
 
 
 def info():
-    phymem = psutil.phymem_usage()
+    mem = psutil.virtual_memory()
+    memused = mem.used - mem.cached
 
     cpu_dashes, cpu_empty_dashes = get_dashes(psutil.cpu_percent(interval=0.1))
     line = "%s/%sMB [%s%s] %s%%" % (
-        str(int(phymem.used / 1024 / 1024)),
-        str(int(phymem.total / 1024 / 1024)),
+        str(int(memused / 1024 / 1024)),
+        str(int(mem.total / 1024 / 1024)),
         cpu_dashes, cpu_empty_dashes,
         psutil.cpu_percent(interval=0.1),
     )


### PR DESCRIPTION
- Check virtual_memory instead of physical memory.
- Omit cached memory, only actively used memory.
